### PR TITLE
Remove whenever and schedule.rb

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,6 @@ gem 'httparty'
 gem 'slim'
 gem 'twilio-ruby'
 gem 'bootswatch-rails'
-gem 'whenever'
 
 group :production do
   gem "sentry-raven"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,7 +62,6 @@ GEM
     chromedriver-helper (1.2.0)
       archive-zip (~> 0.10)
       nokogiri (~> 1.8)
-    chronic (0.10.2)
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
     crack (0.4.3)
@@ -189,8 +188,6 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
-    whenever (0.10.0)
-      chronic (>= 0.6.3)
     xpath (3.0.0)
       nokogiri (~> 1.8)
 
@@ -220,7 +217,6 @@ DEPENDENCIES
   web-console (>= 3.3.0)
   webmock
   webpacker
-  whenever
 
 BUNDLED WITH
    1.16.1

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-set :output, "/path/to/my/cron_log.log"
-
-every 1.day, at: '9:30 am' do
-  rake "message_sender:send_messages"
-end


### PR DESCRIPTION
Turns out Heroku doesn't support cron. Thus, I am pulling out whenever and switching to Heroku Scheduler.